### PR TITLE
fix: Change asdf:load-system to ql:quickload in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 	sbcl --non-interactive \
 		--eval '(load (merge-pathnames "quicklisp/setup.lisp" (user-homedir-pathname)))' \
 		--eval '(push #p"./" asdf:*central-registry*)' \
-		--eval '(asdf:load-system :sextant)' \
+		--eval '(ql:quickload :sextant)' \
 		--eval '(sb-ext:save-lisp-and-die "sextant" :toplevel #'"'"'sextant:main :executable t :compression t)'
 
 clean:


### PR DESCRIPTION
# Issue
`adsf:load-system` expects dependencies to be fetched and available locally, causing builds to fail on fresh sbcl/quicklisp installs.

# Proposed fix
`ql:quickload` fetches the project dependencies when project is built on a fresh sbcl/quicklisp installation.