### PR TITLE
fix: Change asdf:load-system to ql:quickload 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 	sbcl --non-interactive \
 		--eval '(load (merge-pathnames "quicklisp/setup.lisp" (user-homedir-pathname)))' \
 		--eval '(push #p"./" asdf:*central-registry*)' \
-		--eval '(asdf:load-system :sextant)' \
+		--eval '(ql:quickload :sextant)' \
 		--eval '(sb-ext:save-lisp-and-die "sextant" :toplevel #'"'"'sextant:main :executable t :compression t)'
 
 clean:


### PR DESCRIPTION
# Issue 
asdf load-system is used in the Makefile for building the project. Using load-system as such requires a separate step to fetch dependencies which currently does not exist.

# Fix
Using ql:quickload, dependencies get pulled in automatically, allowing `make` to run smoothly on fresh sbcl/quicklisp installs.