### PR TITLE
Ensure publish-diagnostics sends empty JSON array

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,9 @@
+# TODO
+
+## Bugs/Issues
+- Diagnostics don't appear to use the corect line/col positioning, and instead appear at the first line/col of the file.
+- difficult to get completions to consistently appear
+- often the output of completion previews is too spacious, and the preview window is too small to be useful. This is especially bad when the completion item has a long documentation string, which is often the case.
+- subpackage functions don't correctly resolve the same way as top level functions for some reason, and as such don't have describe text in the preview
+-
+## Enhancements

--- a/src/handlers.lisp
+++ b/src/handlers.lisp
@@ -1039,23 +1039,25 @@ deltaLine, deltaStartChar, length, tokenType, tokenModifiers."
   (let ((text (document-text uri)))
     (when text
       (let ((diags (compile-and-collect-diagnostics text)))
-        (let ((notification
-                (make-notification
-                 "textDocument/publishDiagnostics"
-                 (make-json-object
-                  "uri" uri
-                  "diagnostics" (mapcar
-                                 (lambda (d)
-                                   (destructuring-bind (line col message severity) d
-                                     (make-json-object
-                                      "range" (make-json-object
-                                                "start" (make-json-object "line" line "character" col)
-                                                "end" (make-json-object "line" line "character" col))
-                                      "severity" severity
-                                      "source" "sextant"
-                                      "message" message)))
-                                 diags)))))
-          (write-lsp-message notification *lsp-output*))))))
+        (let ((diagnostics-value (if (null diags)
+                                     (json-empty-array)
+                                     (mapcar (lambda (d)
+                                               (destructuring-bind (line col message severity) d
+                                                 (make-json-object
+                                                  "range" (make-json-object
+                                                            "start" (make-json-object "line" line "character" col)
+                                                            "end" (make-json-object "line" line "character" col))
+                                                  "severity" severity
+                                                  "source" "sextant"
+                                                  "message" message)))
+                                             diags))))
+          (let ((notification
+                 (make-notification
+                  "textDocument/publishDiagnostics"
+                  (make-json-object
+                   "uri" uri
+                   "diagnostics" diagnostics-value))))
+            (write-lsp-message notification *lsp-output*)))))))
 
 ;;; --- Document Sync ---
 

--- a/src/json.lisp
+++ b/src/json.lisp
@@ -5,22 +5,37 @@
 ;;; No external dependencies - just enough for LSP JSON-RPC
 ;;; ============================================================
 
+;;; Sentinel to explicitly represent an empty JSON array when NIL might be overloaded.
+(defconstant +json-empty-array+ :json-empty-array
+  "A unique sentinel value representing an explicit empty JSON array '[]' in serialized output.")
+
+(defun json-empty-array ()
+  "Return the sentinel value that serializes to an empty JSON array."
+  +json-empty-array+)
+
 ;;; --- JSON Writing ---
 
 (defun json-write (obj stream)
   "Write OBJ as JSON to STREAM."
-  (etypecase obj
-    (null (write-string "null" stream))
-    ((eql t) (write-string "true" stream))
-    ((eql :false) (write-string "false" stream))
-    (integer (format stream "~d" obj))
-    (float (format stream "~f" obj))
-    (string (json-write-string obj stream))
-    (keyword (json-write-string (string-downcase (symbol-name obj)) stream))
-    (hash-table (json-write-object obj stream))
-    (list (if (json-alist-p obj)
-              (json-write-alist obj stream)
-              (json-write-array obj stream)))))
+  (cond
+    ;; Sentinel: explicit empty JSON array
+    ((eq obj +json-empty-array+) (write-string "[]" stream))
+    ;; Lists (including the empty list NIL) are serialized as JSON arrays.
+    ((listp obj)
+     (if (json-alist-p obj)
+         (json-write-alist obj stream)
+         (json-write-array obj stream)))
+    ;; Explicit JSON null remains representable by the symbol :json-null if needed;
+    ;; fall back to writing "null" for NIL values that are not lists.
+    ((null obj) (write-string "null" stream))
+    ((eql obj t) (write-string "true" stream))
+    ((eql obj :false) (write-string "false" stream))
+    ((integerp obj) (format stream "~d" obj))
+    ((floatp obj) (format stream "~f" obj))
+    ((stringp obj) (json-write-string obj stream))
+    ((keywordp obj) (json-write-string (string-downcase (symbol-name obj)) stream))
+    ((hash-table-p obj) (json-write-object obj stream))
+    (t (error "json-write: unsupported type ~a" (type-of obj)))))
 
 (defun json-write-string (s stream)
   "Write S as a JSON string with escaping."

--- a/src/transport.lisp
+++ b/src/transport.lisp
@@ -74,6 +74,17 @@ Content-Length is in bytes, so we read bytes and decode to UTF-8."
             body)
     (force-output stream)))
 
+(defun write-lsp-body (body &optional (stream *lsp-output*))
+  "Write BODY (a JSON string) as an LSP message without further serialization.
+This is a small escape hatch used when the JSON writer cannot represent a value
+exactly as needed (e.g. distinguishing JSON null from an empty array)."
+  (lsp-log ">>> (raw) ~a" body)
+  (format stream "Content-Length: ~d~c~c~c~c~a"
+          (length (babel:string-to-octets body :encoding :utf-8))
+          #\Return #\Linefeed #\Return #\Linefeed
+          body)
+  (force-output stream))
+
 (defun make-response (id result)
   "Create a JSON-RPC response for request ID with RESULT."
   (make-json-object "jsonrpc" "2.0"


### PR DESCRIPTION
# Issue
Currently, server returns `diagnostics: null`
This is the result of the JSON parser interpreting `()` as the JSON null object, which is semantically correct as common lisp overloads NIL to the empty list. This results in behavior which is, unfortunately, not correct to the LSP spec, and as such is not expected in neovim's lsp diagnostic implementation, causing a validation error to occur on receipt of the LSP response object.

# Fix
- Create a sentinel function which returns a constant representing the JSON empty array object.
- When an empty list is present in the diagnostics output, pass the sentinel constant to the JSON parser instead of the empty list.