### PR TITLE
fix: accurate diagnostic location reporting

### DIFF
--- a/src/diagnostics.lisp
+++ b/src/diagnostics.lisp
@@ -40,37 +40,51 @@
 
 ;;; --- Source location extraction from SBCL compiler internals ---
 
+(defun extract-source-path-position (text)
+  "Extract a precise source position from SBCL's source-path data when available.
+Source-paths are set on IR nodes and encode the exact form path.
+Returns (line . col) or NIL."
+  (when (and (boundp 'sb-c::*compiler-error-context*)
+             (symbol-value 'sb-c::*compiler-error-context*))
+    (let ((ctx (symbol-value 'sb-c::*compiler-error-context*)))
+      (when (ignore-errors (slot-boundp ctx 'sb-c::source-path))
+        (let ((sp (ignore-errors (slot-value ctx 'sb-c::source-path))))
+          (when (and sp (listp sp))
+            (extract-position-from-source-path sp text)))))))
+
 (defun extract-compiler-context-position (text)
   "Extract source position from SBCL's *compiler-error-context*.
+Tries source-path first (precise), then file-position (form-level only).
 Returns (line . col) or NIL."
   (when (and (boundp 'sb-c::*compiler-error-context*)
              (symbol-value 'sb-c::*compiler-error-context*))
     (let ((ctx (symbol-value 'sb-c::*compiler-error-context*)))
       (or
-       ;; COMPILER-ERROR-CONTEXT has FILE-POSITION (byte offset)
+       ;; Source-path: precise sub-form position (IR nodes only)
+       (when (ignore-errors (slot-boundp ctx 'sb-c::source-path))
+         (let ((sp (ignore-errors (slot-value ctx 'sb-c::source-path))))
+           (when (and sp (listp sp))
+             (extract-position-from-source-path sp text))))
+       ;; File-position: position after reading the enclosing top-level form.
+       ;; Rough — points to the form boundary, not the exact error site.
        (when (typep ctx 'sb-c::compiler-error-context)
          (let ((fpos (ignore-errors
                        (slot-value ctx 'sb-c::file-position))))
            (when (and fpos (integerp fpos) (> fpos 0))
-             (offset-to-line-col text (min fpos (length text))))))
-       ;; IR nodes (COMBINATION, BIND, etc.) have SOURCE-PATH
-       ;; containing (ORIGINAL-SOURCE-START form-idx subform...)
-       (when (ignore-errors (slot-boundp ctx 'sb-c::source-path))
-         (let ((sp (ignore-errors (slot-value ctx 'sb-c::source-path))))
-           (when (and sp (listp sp))
-             (extract-position-from-source-path sp text))))))))
+             (offset-to-line-col text (min fpos (length text))))))))))
+
 
 (defun extract-position-from-source-path (source-path text)
   "Convert an SBCL source-path to (line . col).
-SOURCE-PATH is like (ORIGINAL-SOURCE-START form-idx subform-idx ...)."
-  ;; Find ORIGINAL-SOURCE-START marker and get the top-level form index
+SOURCE-PATH is like (ORIGINAL-SOURCE-START form-idx subform-idx ...) where
+each index after the top-level form index navigates into a nested sub-form."
   (let ((oss-pos (position 'sb-c::original-source-start source-path)))
     (when oss-pos
       (let* ((indices (subseq source-path (1+ oss-pos)))
-             (form-idx (first indices)))
+             (form-idx (first indices))
+             (sub-indices (rest indices)))
         (when (and form-idx (integerp form-idx))
-          ;; Find the start position of the nth top-level form
-          (find-nth-toplevel-form-position text form-idx))))))
+          (navigate-source-path text form-idx sub-indices))))))
 
 (defun skip-whitespace-and-comments (stream)
   "Advance STREAM past whitespace and line comments.
@@ -116,7 +130,7 @@ Returns the file-position of the first non-whitespace, non-comment character."
 Returns (line . col) or NIL."
   (handler-case
       (with-input-from-string (stream text)
-        (let ((form-count 0))ou switch 
+        (let ((form-count 0))
           (loop
             ;; Skip whitespace and comments to find actual form start
             (let ((pos (skip-whitespace-and-comments stream)))
@@ -128,6 +142,47 @@ Returns (line . col) or NIL."
                   ;; This is the form we want
                   (return (offset-to-line-col text (min pos (length text)))))
                 (incf form-count))))))
+    (error () nil)))
+
+(defun navigate-source-path (text form-idx sub-indices)
+  "Find the precise source position indicated by FORM-IDX and SUB-INDICES.
+First locates the FORM-IDX-th top-level form, then descends into sub-forms
+following each index in SUB-INDICES.
+Returns (line . col) or NIL."
+  (handler-case
+      (with-input-from-string (stream text)
+        ;; Advance to the Nth top-level form
+        (let ((form-start nil))
+          (dotimes (i (1+ form-idx))
+            (skip-whitespace-and-comments stream)
+            (let ((pos (file-position stream)))
+              (let ((form (read stream nil :eof)))
+                (when (eq form :eof) (return-from navigate-source-path nil))
+                (when (= i form-idx)
+                  (setf form-start pos)))))
+          ;; If no sub-indices, return the top-level form start
+          (when (or (null sub-indices) (null form-start))
+            (return-from navigate-source-path
+              (when form-start (offset-to-line-col text (min form-start (length text))))))
+          ;; Re-read from form-start with source positions
+          (file-position stream form-start)
+          (let ((form (read stream nil :eof)))
+            (when (eq form :eof) (return-from navigate-source-path nil))
+            ;; Navigate into sub-forms following the index path
+            (let ((current form))
+              (dolist (idx sub-indices)
+                (unless (and (listp current) (integerp idx) (< idx (length current)))
+                  (return-from navigate-source-path
+                    (offset-to-line-col text (min form-start (length text)))))
+                (setf current (nth idx current)))
+              ;; Now find the position of CURRENT within the top-level form text
+              (let* ((form-text (subseq text form-start
+                                        (min (file-position stream) (length text))))
+                     (target (string-downcase (princ-to-string current)))
+                     (rel-pos (search target (string-downcase form-text))))
+                (if rel-pos
+                    (offset-to-line-col text (+ form-start rel-pos))
+                    (offset-to-line-col text (min form-start (length text)))))))))
     (error () nil)))
 
 (defun extract-position-from-condition (condition text)
@@ -187,24 +242,81 @@ Returns (line . col) or NIL."
        (declare (ignore match))
        (when groups (aref groups 0))))))
 
+(defun position-in-comment-or-string-p (text offset)
+  "Return T if OFFSET in TEXT falls inside a line comment, block comment, or string literal.
+Scans from the beginning of TEXT, tracking reader state."
+  (let ((i 0)
+        (len (length text))
+        (in-string nil)
+        (escape nil))
+    (loop while (< i offset)
+          do (let ((c (char text i)))
+               (cond
+                 ;; Inside a string: only escape and closing quote matter
+                 (in-string
+                  (cond
+                    (escape (setf escape nil))
+                    ((char= c #\\) (setf escape t))
+                    ((char= c #\") (setf in-string nil))))
+                 ;; Block comment: #| ... |#  (nestable)
+                 ((and (char= c #\#)
+                       (< (1+ i) len)
+                       (char= (char text (1+ i)) #\|))
+                  (incf i 2) ; consume #|
+                  (let ((depth 1))
+                    (loop while (and (< i offset) (> depth 0))
+                          do (cond
+                               ((and (char= (char text i) #\#)
+                                     (< (1+ i) len)
+                                     (char= (char text (1+ i)) #\|))
+                                (incf depth) (incf i 2))
+                               ((and (char= (char text i) #\|)
+                                     (< (1+ i) len)
+                                     (char= (char text (1+ i)) #\#))
+                                (decf depth) (incf i 2))
+                               (t (incf i))))
+                    ;; If we hit OFFSET while still inside the block comment, it's a comment
+                    (when (> depth 0) (return-from position-in-comment-or-string-p t)))
+                  (decf i)) ; loop will incf below
+                 ;; Line comment: ; ... \n
+                 ((char= c #\;)
+                  ;; Everything from here to end-of-line is a comment;
+                  ;; if offset is in this range, it's inside a comment
+                  (let ((eol (or (position #\Newline text :start i) len)))
+                    (when (< offset eol)
+                      (return-from position-in-comment-or-string-p t))
+                    ;; Skip to the newline
+                    (setf i eol)
+                    (decf i))) ; loop will incf below
+                 ;; String open
+                 ((char= c #\") (setf in-string t))))
+             (incf i))
+    ;; If we ended inside a string literal, the offset is inside it
+    in-string))
+
 (defun find-symbol-position-in-text (text symbol-name)
-  "Find the best occurrence of SYMBOL-NAME in TEXT.
-Prefers occurrences in code (not comments). Returns (line . col) or NIL."
+  "Find the first occurrence of SYMBOL-NAME in TEXT that is in code (not a
+comment or string) and is a whole-symbol match (word boundaries).
+Returns (line . col) or NIL."
   (when (and text symbol-name (> (length symbol-name) 0))
     (let* ((downcased (string-downcase text))
-           (target (string-downcase symbol-name)))
-      ;; Search for the symbol, skipping comment lines
-      (let ((pos 0))
-        (loop
-          (let ((found (search target downcased :start2 pos)))
-            (unless found (return nil))
-            ;; Check if this occurrence is inside a comment
-            (let ((line-start (or (position #\Newline text :end found :from-end t) -1)))
-              (let ((before-on-line (subseq text (1+ line-start) found)))
-                (unless (search ";" before-on-line)
-                  ;; Not in a comment - return this position
-                  (return (offset-to-line-col text found)))))
-            (setf pos (1+ found))))))))
+           (target (string-downcase symbol-name))
+           (tlen (length target))
+           (tlen-text (length text))
+           (pos 0))
+      (loop
+        (let ((found (search target downcased :start2 pos)))
+          (unless found (return nil))
+          ;; Word-boundary check: chars immediately outside the match must not
+          ;; be symbol constituents.
+          (let ((left-ok  (or (zerop found)
+                              (not (symbol-char-p (char text (1- found))))))
+                (right-ok (or (>= (+ found tlen) tlen-text)
+                              (not (symbol-char-p (char text (+ found tlen)))))))
+            (when (and left-ok right-ok
+                       (not (position-in-comment-or-string-p text found)))
+              (return (offset-to-line-col text found))))
+          (setf pos (1+ found)))))))
 
 (defvar *diagnostics-temp-file*
   (merge-pathnames "sextant-diag.lisp" (uiop:temporary-directory))
@@ -271,28 +383,35 @@ Returns a list of captured-condition structs."
                   (lambda (c)
                     (let ((msg (princ-to-string c)))
                       (unless (noise-warning-p msg)
-                        (let* ((sym (extract-symbol-from-warning c))
-                               (sym-pos (when sym
-                                          (find-symbol-position-in-text text sym)))
-                               (ctx-pos (extract-position-from-condition c text)))
+                        (let* ((sym     (extract-symbol-from-warning c))
+                               ;; Best: symbol search with word-boundary + comment/string awareness
+                               (sym-pos (when sym (find-symbol-position-in-text text sym)))
+                               ;; Fallback: SBCL source-path (imprecise for style warnings)
+                               (sp-pos  (when (null sym-pos)
+                                          (extract-source-path-position text)))
+                               ;; Rough fallback: enclosing form boundary
+                               (ctx-pos (when (and (null sym-pos) (null sp-pos))
+                                          (extract-position-from-condition c text))))
                           (push (make-captured-condition
                                  :message msg
                                  :severity (condition-severity c)
-                                 ;; Prefer symbol-level position over form-level
-                                 :position (or sym-pos ctx-pos)
+                                 :position (or sym-pos sp-pos ctx-pos)
                                  :source-form sym)
                                 conditions))))
                     (muffle-warning c)))
                 (error
                   (lambda (c)
-                    (let ((msg (princ-to-string c)))
+                    (let* ((msg     (princ-to-string c))
+                           (sym     (extract-symbol-from-warning c))
+                           (sym-pos (when sym (find-symbol-position-in-text text sym)))
+                           (sp-pos  (when (null sym-pos)
+                                      (extract-source-path-position text)))
+                           (ctx-pos (when (and (null sym-pos) (null sp-pos))
+                                      (extract-position-from-condition c text))))
                       (push (make-captured-condition
                              :message msg
                              :severity +severity-error+
-                             :position (or (extract-position-from-condition c text)
-                                           (let ((sym (extract-symbol-from-warning c)))
-                                             (when sym
-                                               (find-symbol-position-in-text text sym)))))
+                             :position (or sym-pos sp-pos ctx-pos))
                             conditions))
                     ;; Return what we have so far
                     (return-from compile-buffer-for-diagnostics

--- a/src/diagnostics.lisp
+++ b/src/diagnostics.lisp
@@ -144,14 +144,37 @@ Returns (line . col) or NIL."
                 (incf form-count))))))
     (error () nil)))
 
+(defun read-into-nth-subform (stream idx)
+  "With STREAM at or before the opening paren of a list form, position STREAM
+at the start of the IDX-th element (0-indexed) within that list.
+Returns the file-position of the IDX-th sub-form, or NIL if not found."
+  (handler-case
+      (progn
+        ;; Skip whitespace to the opening paren
+        (peek-char t stream nil nil)
+        (let ((c (peek-char nil stream nil nil)))
+          (unless (and c (char= c #\())
+            (return-from read-into-nth-subform nil)))
+        (read-char stream) ; consume (
+        ;; Skip IDX sub-forms
+        (dotimes (i idx)
+          (let ((sub (read stream nil :eof)))
+            (when (eq sub :eof)
+              (return-from read-into-nth-subform nil))))
+        ;; Skip whitespace to the IDX-th sub-form
+        (peek-char t stream nil nil)
+        (file-position stream))
+    (error () nil)))
+
 (defun navigate-source-path (text form-idx sub-indices)
   "Find the precise source position indicated by FORM-IDX and SUB-INDICES.
-First locates the FORM-IDX-th top-level form, then descends into sub-forms
-following each index in SUB-INDICES.
+Locates the FORM-IDX-th top-level form, then descends into sub-forms following
+each index in SUB-INDICES using stream file-positions. This avoids both
+(length list) on dotted pairs and princ-to-string ambiguity for repeated forms.
 Returns (line . col) or NIL."
   (handler-case
       (with-input-from-string (stream text)
-        ;; Advance to the Nth top-level form
+        ;; Advance to the target top-level form, recording its start position
         (let ((form-start nil))
           (dotimes (i (1+ form-idx))
             (skip-whitespace-and-comments stream)
@@ -160,29 +183,22 @@ Returns (line . col) or NIL."
                 (when (eq form :eof) (return-from navigate-source-path nil))
                 (when (= i form-idx)
                   (setf form-start pos)))))
-          ;; If no sub-indices, return the top-level form start
-          (when (or (null sub-indices) (null form-start))
+          (unless form-start
+            (return-from navigate-source-path nil))
+          ;; No sub-indices: return position of the top-level form itself
+          (when (null sub-indices)
             (return-from navigate-source-path
-              (when form-start (offset-to-line-col text (min form-start (length text))))))
-          ;; Re-read from form-start with source positions
-          (file-position stream form-start)
-          (let ((form (read stream nil :eof)))
-            (when (eq form :eof) (return-from navigate-source-path nil))
-            ;; Navigate into sub-forms following the index path
-            (let ((current form))
-              (dolist (idx sub-indices)
-                (unless (and (listp current) (integerp idx) (< idx (length current)))
+              (offset-to-line-col text (min form-start (length text)))))
+          ;; Descend into sub-forms by tracking stream file-positions
+          (let ((current-pos form-start))
+            (dolist (idx sub-indices)
+              (file-position stream current-pos)
+              (let ((sub-pos (read-into-nth-subform stream idx)))
+                (unless sub-pos
                   (return-from navigate-source-path
                     (offset-to-line-col text (min form-start (length text)))))
-                (setf current (nth idx current)))
-              ;; Now find the position of CURRENT within the top-level form text
-              (let* ((form-text (subseq text form-start
-                                        (min (file-position stream) (length text))))
-                     (target (string-downcase (princ-to-string current)))
-                     (rel-pos (search target (string-downcase form-text))))
-                (if rel-pos
-                    (offset-to-line-col text (+ form-start rel-pos))
-                    (offset-to-line-col text (min form-start (length text)))))))))
+                (setf current-pos sub-pos)))
+            (offset-to-line-col text (min current-pos (length text))))))
     (error () nil)))
 
 (defun extract-position-from-condition (condition text)
@@ -243,8 +259,10 @@ Returns (line . col) or NIL."
        (when groups (aref groups 0))))))
 
 (defun position-in-comment-or-string-p (text offset)
-  "Return T if OFFSET in TEXT falls inside a line comment, block comment, or string literal.
-Scans from the beginning of TEXT, tracking reader state."
+  "Return T if OFFSET in TEXT falls inside a line comment, block comment, string
+literal, or pipe-escaped symbol (|...|).
+Handles #\\x character literals to avoid false positives from #\\; etc.
+Note: #; (read-time suppress) is not handled and is a known limitation."
   (let ((i 0)
         (len (length text))
         (in-string nil)
@@ -258,40 +276,58 @@ Scans from the beginning of TEXT, tracking reader state."
                     (escape (setf escape nil))
                     ((char= c #\\) (setf escape t))
                     ((char= c #\") (setf in-string nil))))
-                 ;; Block comment: #| ... |#  (nestable)
-                 ((and (char= c #\#)
-                       (< (1+ i) len)
-                       (char= (char text (1+ i)) #\|))
-                  (incf i 2) ; consume #|
-                  (let ((depth 1))
-                    (loop while (and (< i offset) (> depth 0))
-                          do (cond
-                               ((and (char= (char text i) #\#)
-                                     (< (1+ i) len)
-                                     (char= (char text (1+ i)) #\|))
-                                (incf depth) (incf i 2))
-                               ((and (char= (char text i) #\|)
-                                     (< (1+ i) len)
-                                     (char= (char text (1+ i)) #\#))
-                                (decf depth) (incf i 2))
-                               (t (incf i))))
-                    ;; If we hit OFFSET while still inside the block comment, it's a comment
-                    (when (> depth 0) (return-from position-in-comment-or-string-p t)))
-                  (decf i)) ; loop will incf below
+                 ;; Dispatching macros starting with #
+                 ((char= c #\#)
+                  (let ((next (and (< (1+ i) len) (char text (1+ i)))))
+                    (cond
+                      ;; #| ... |# nestable block comment
+                      ((and next (char= next #\|))
+                       (incf i 2) ; consume #|
+                       (let ((depth 1))
+                         (loop while (and (< i offset) (> depth 0))
+                               do (cond
+                                    ((and (char= (char text i) #\#)
+                                          (< (1+ i) len)
+                                          (char= (char text (1+ i)) #\|))
+                                     (incf depth) (incf i 2))
+                                    ((and (char= (char text i) #\|)
+                                          (< (1+ i) len)
+                                          (char= (char text (1+ i)) #\#))
+                                     (decf depth) (incf i 2))
+                                    (t (incf i))))
+                         (when (> depth 0)
+                           (return-from position-in-comment-or-string-p t)))
+                       (decf i)) ; outer loop will incf
+                      ;; #\x character literal: consume #, \, and one char (total 3)
+                      ((and next (char= next #\\))
+                       (incf i 2)) ; consume #\ and the literal char; outer incf passes it
+                      ;; Other # forms: let the outer loop advance normally
+                      (t nil))))
+                 ;; Pipe-escaped symbol: |...| — treat interior as non-code
+                 ((char= c #\|)
+                  (incf i) ; consume opening |
+                  (loop
+                    (when (>= i offset)
+                      (return-from position-in-comment-or-string-p t))
+                    (when (>= i len) (return))
+                    (let ((pc (char text i)))
+                      (cond
+                        ((char= pc #\\) (incf i 2)) ; escaped char inside pipes
+                        ((char= pc #\|) (return))   ; end of pipe symbol
+                        (t (incf i)))))
+                  ;; i now points to closing | (or ran past len); decf so outer incf passes it
+                  (decf i))
                  ;; Line comment: ; ... \n
                  ((char= c #\;)
-                  ;; Everything from here to end-of-line is a comment;
-                  ;; if offset is in this range, it's inside a comment
                   (let ((eol (or (position #\Newline text :start i) len)))
                     (when (< offset eol)
                       (return-from position-in-comment-or-string-p t))
-                    ;; Skip to the newline
                     (setf i eol)
-                    (decf i))) ; loop will incf below
+                    (decf i))) ; outer loop will incf
                  ;; String open
                  ((char= c #\") (setf in-string t))))
              (incf i))
-    ;; If we ended inside a string literal, the offset is inside it
+    ;; If we ended still inside a string literal, the offset is inside it
     in-string))
 
 (defun find-symbol-position-in-text (text symbol-name)
@@ -308,9 +344,14 @@ Returns (line . col) or NIL."
         (let ((found (search target downcased :start2 pos)))
           (unless found (return nil))
           ;; Word-boundary check: chars immediately outside the match must not
-          ;; be symbol constituents.
+          ;; be symbol constituents, except that ':' and '#' are valid left
+          ;; boundaries because they are package/uninterned prefixes (pkg::foo,
+          ;; pkg:foo, #:foo) — not continuations of a different symbol name.
           (let ((left-ok  (or (zerop found)
-                              (not (symbol-char-p (char text (1- found))))))
+                              (let ((lc (char text (1- found))))
+                                (or (not (symbol-char-p lc))
+                                    (char= lc #\:)
+                                    (char= lc #\#)))))
                 (right-ok (or (>= (+ found tlen) tlen-text)
                               (not (symbol-char-p (char text (+ found tlen)))))))
             (when (and left-ok right-ok


### PR DESCRIPTION
## Problem

Diagnostics were reported at incorrect positions. The clearest symptom: appending a bare `a` to a file would squiggle the first `a` found inside a comment or symbol name rather than the actual error site.

## Root Causes Fixed

**1. Missing word-boundary checks** (`find-symbol-position-in-text`)  
Plain `search` accepted any substring. Searching for `A` (from "undefined variable: AOC25::A") matched the `a` at offset 5 inside the token `#:AoC25`. Fixed by checking that chars immediately outside the match are not symbol constituents.

**2. Naive comment/string detection**  
The old check was `(search ";" before-on-line)` on raw text — false positives for `;` inside strings, and block comments (`#|…|#`) were ignored entirely. Replaced with `position-in-comment-or-string-p`, a full scanner that tracks line comments, nestable block comments, and string literals.

**3. Wrong position priority in `compile-buffer-for-diagnostics`**  
SBCL source-paths for style warnings (e.g. "variable Y is unused") often point to the enclosing form's operator rather than the specific symbol. `sym-pos` (symbol text search) is more accurate when a symbol name is available. New priority: `sym-pos → sp-pos → ctx-pos`.

**4. Typo that silently broke source-path navigation**  
`find-nth-toplevel-form-position` had stray symbols `ou switch` in its body that caused it to always return `nil` via a caught error, making all source-path-based position lookup silently fail. Removed.

**5. Add `navigate-source-path`**  
For diagnostics with no extractable symbol name (e.g. "Constant \"not a number\" conflicts with type"), follows SBCL's source-path sub-form indices to locate the precise sub-expression.

## Testing

- AoC regression: appending `a` now reports `(22 . 0)` (end of file), not `(0 . 5)` (inside a comment token).
- Baseline: all 5 existing diagnostics in `test-diagnostics.lisp` remain at correct positions.
- Symbol inside string: correctly skipped, code occurrence found.
- Symbol inside block comment: correctly skipped, code occurrence found.