### PR TITLE
handlers: return isIncomplete:true instead of null for short prefix

### DIFF
--- a/src/handlers.lisp
+++ b/src/handlers.lisp
@@ -180,22 +180,28 @@
          (pos (json-get params "position"))
          (line (json-get pos "line"))
          (col (json-get pos "character"))
-         (text (document-text uri)))
-    (when text
-      (let ((prefix (symbol-at-position text line col)))
-        (when (and prefix (>= (length prefix) 2))
-          (lsp-log "Complete: ~a" prefix)
-          (let ((completions (symbol-completions prefix)))
-            (make-json-object
-             "isIncomplete" :false
-             "items" (mapcar
-                      (lambda (c)
-                        (destructuring-bind (name kind pkg) c
-                          (make-json-object
-                           "label" name
-                           "kind" kind
-                           "detail" (format nil "~(~a~)" pkg))))
-                      completions))))))))
+         (text (document-text uri))
+         (empty (make-json-object "isIncomplete" :true "items" (list))))
+    (if (not text)
+        empty
+        (let ((prefix (symbol-at-position text line col)))
+          ;; Return isIncomplete:true when prefix is absent or too short so
+          ;; clients know to keep requesting on each keystroke.
+          (if (or (not prefix) (< (length prefix) 2))
+              empty
+              (progn
+                (lsp-log "Complete: ~a" prefix)
+                (let ((completions (symbol-completions prefix)))
+                  (make-json-object
+                   "isIncomplete" :false
+                   "items" (mapcar
+                            (lambda (c)
+                              (destructuring-bind (name kind pkg) c
+                                (make-json-object
+                                 "label" name
+                                 "kind" kind
+                                 "detail" (format nil "~(~a~)" pkg))))
+                            completions)))))))))
 
 ;;; --- Go to Definition ---
 

--- a/src/handlers.lisp
+++ b/src/handlers.lisp
@@ -181,7 +181,7 @@
          (line (json-get pos "line"))
          (col (json-get pos "character"))
          (text (document-text uri))
-         (empty (make-json-object "isIncomplete" :true "items" (list))))
+         (empty (make-json-object "isIncomplete" t "items" (list))))
     (if (not text)
         empty
         (let ((prefix (symbol-at-position text line col)))


### PR DESCRIPTION
When `handle-completion` has no text or a short prefix, it returned `nil` (JSON `null`). Clients like blink.cmp treat `null` as a terminal signal and stop requesting completions on subsequent keystrokes — this is why completions only appeared after re-entering insert mode.

Fix: return `{"isIncomplete": true, "items": []}` so clients continue requesting as the user types.