### PR TITLE
feat(roswell, ci): add Roswell install script and release pipeline; fix diagnostic source positions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,10 @@ jobs:
       - name: Resolve roswell-managed sbcl onto PATH
         run: |
           echo "$HOME/.roswell/bin" >> "$GITHUB_PATH"
-          SBCL_BIN=$("$HOME/.roswell/bin/ros" run -- --non-interactive --no-userinit \
-            --eval '(princ (sb-ext:native-namestring sb-ext:*runtime-pathname*))' --quit 2>/dev/null | tail -1)
-          [ -n "$SBCL_BIN" ] || { echo "failed to resolve sbcl binary path" >&2; exit 1; }
-          dirname "$SBCL_BIN" >> "$GITHUB_PATH"
+          ros_home="${ROSWELL_HOME:-$HOME/.roswell}"
+          sbcl_bin=$(find "$ros_home/impls" -type f -path '*/sbcl-bin/*/bin/sbcl' | sort -V | tail -1)
+          [ -n "$sbcl_bin" ] || { echo "no roswell sbcl-bin under $ros_home/impls" >&2; exit 1; }
+          dirname "$sbcl_bin" >> "$GITHUB_PATH"
 
       - name: Verify sbcl (core compression support)
         run: sbcl --non-interactive --eval '(unless (find :sb-core-compression *features*) (sb-ext:exit :code 1))'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,12 @@ name: Release
 on:
   push:
     branches:
-      - packaging
+      - master
     tags:
       - 'v*'
+  pull_request:
+    branches:
+      - master
 
 permissions:
   contents: read
@@ -48,6 +51,9 @@ jobs:
         run: |
           curl -fsSL -o /tmp/quicklisp.lisp https://beta.quicklisp.org/quicklisp.lisp
           sbcl --non-interactive --load /tmp/quicklisp.lisp --eval '(quicklisp-quickstart:install)'
+
+      - name: Test
+        run: make test
 
       - name: Build
         run: make build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - packaging
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build (${{ matrix.platform }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux-x64
+          - os: ubuntu-24.04-arm
+            platform: linux-arm64
+          - os: macos-14
+            platform: macos-arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Roswell (sbcl-bin)
+        env:
+          LISP: sbcl-bin
+        run: curl -fsSL https://raw.githubusercontent.com/roswell/roswell/master/scripts/install-for-ci.sh | sh
+
+      - name: Resolve roswell-managed sbcl onto PATH
+        run: |
+          echo "$HOME/.roswell/bin" >> "$GITHUB_PATH"
+          SBCL_BIN=$("$HOME/.roswell/bin/ros" run -- --non-interactive --no-userinit \
+            --eval '(princ (sb-ext:native-namestring sb-ext:*runtime-pathname*))' --quit 2>/dev/null | tail -1)
+          [ -n "$SBCL_BIN" ] || { echo "failed to resolve sbcl binary path" >&2; exit 1; }
+          dirname "$SBCL_BIN" >> "$GITHUB_PATH"
+
+      - name: Verify sbcl (core compression support)
+        run: sbcl --non-interactive --eval '(unless (find :sb-core-compression *features*) (sb-ext:exit :code 1))'
+
+      - name: Bootstrap Quicklisp
+        run: |
+          curl -fsSL -o /tmp/quicklisp.lisp https://beta.quicklisp.org/quicklisp.lisp
+          sbcl --non-interactive --load /tmp/quicklisp.lisp --eval '(quicklisp-quickstart:install)'
+
+      - name: Build
+        run: make build
+
+      - name: Smoke check
+        run: python3 ci/smoke_check.py ./sextant
+
+      - name: Rename binary for release
+        run: mv sextant sextant-${{ matrix.platform }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sextant-${{ matrix.platform }}
+          path: sextant-${{ matrix.platform }}
+          if-no-files-found: error
+
+  release:
+    name: Publish release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: sextant-*
+          path: dist
+          merge-multiple: true
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" dist/sextant-* \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+            --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           - os: macos-14
             platform: macos-arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Roswell (sbcl-bin)
         env:
@@ -64,7 +64,7 @@ jobs:
       - name: Rename binary for release
         run: mv sextant sextant-${{ matrix.platform }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: sextant-${{ matrix.platform }}
           path: sextant-${{ matrix.platform }}
@@ -79,7 +79,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: sextant-*
           path: dist

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ test:
 	sbcl --non-interactive \
 		--eval '(load (merge-pathnames "quicklisp/setup.lisp" (user-homedir-pathname)))' \
 		--eval '(push #p"./" asdf:*central-registry*)' \
-		--eval '(asdf:test-system :sextant)'
+		--eval '(ql:quickload "sextant/tests")' \
+		--eval '(asdf:test-system "sextant")'
 
 clean:
 	rm -f sextant

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean
+.PHONY: build test clean
 
 build:
 	sbcl --non-interactive \
@@ -6,6 +6,12 @@ build:
 		--eval '(push #p"./" asdf:*central-registry*)' \
 		--eval '(ql:quickload :sextant)' \
 		--eval '(sb-ext:save-lisp-and-die "sextant" :toplevel #'"'"'sextant:main :executable t :compression t)'
+
+test:
+	sbcl --non-interactive \
+		--eval '(load (merge-pathnames "quicklisp/setup.lisp" (user-homedir-pathname)))' \
+		--eval '(push #p"./" asdf:*central-registry*)' \
+		--eval '(asdf:test-system :sextant)'
 
 clean:
 	rm -f sextant

--- a/README.org
+++ b/README.org
@@ -59,6 +59,18 @@ make
 
 This produces a =sextant= executable (~16MB compressed).
 
+** Installing via Roswell
+
+If you have [[https://roswell.github.io/][Roswell]] installed:
+
+#+begin_src bash
+ros install victorzhuk/sextant
+#+end_src
+
+This builds sextant from source via ASDF/Quicklisp and installs it to
+=~/.roswell/bin= (make sure that's on your PATH). Works even before a tagged
+release exists.
+
 ** Emacs Setup (eglot)
 
 #+begin_src emacs-lisp

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,7 @@
 # TODO
 
 ## Bugs/Issues
-- Diagnostics don't appear to use the corect line/col positioning, and instead appear at the first line/col of the file.
 - difficult to get completions to consistently appear
 - often the output of completion previews is too spacious, and the preview window is too small to be useful. This is especially bad when the completion item has a long documentation string, which is often the case.
-- subpackage functions don't correctly resolve the same way as top level functions for some reason, and as such don't have describe text in the preview
--
+
 ## Enhancements

--- a/ci/smoke_check.py
+++ b/ci/smoke_check.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Spawn a built sextant binary and verify it speaks LSP over stdio."""
+import json
+import subprocess
+import sys
+import threading
+import time
+
+READ_TIMEOUT = 10.0
+SHUTDOWN_GRACE = 3.0
+
+
+class Framer:
+    def __init__(self, proc):
+        self.proc = proc
+        self.buf = bytearray()
+        self.cond = threading.Condition()
+        self.eof = False
+        self.thread = threading.Thread(target=self._pump, daemon=True)
+        self.thread.start()
+
+    def _pump(self):
+        while True:
+            chunk = self.proc.stdout.read1(4096)
+            with self.cond:
+                if not chunk:
+                    self.eof = True
+                    self.cond.notify_all()
+                    return
+                self.buf.extend(chunk)
+                self.cond.notify_all()
+
+    def _try_extract(self):
+        sep = self.buf.find(b"\r\n\r\n")
+        if sep == -1:
+            return None
+        header = self.buf[:sep].decode("ascii", errors="replace")
+        length = None
+        for line in header.split("\r\n"):
+            if line.lower().startswith("content-length:"):
+                length = int(line.split(":", 1)[1].strip())
+        if length is None:
+            raise ValueError(f"no Content-Length in header: {header!r}")
+        body_start = sep + 4
+        body_end = body_start + length
+        if len(self.buf) < body_end:
+            return None
+        body = bytes(self.buf[body_start:body_end])
+        del self.buf[:body_end]
+        return json.loads(body.decode("utf-8"))
+
+    def read_message(self, timeout=READ_TIMEOUT):
+        deadline = time.monotonic() + timeout
+        with self.cond:
+            while True:
+                msg = self._try_extract()
+                if msg is not None:
+                    return msg
+                if self.eof:
+                    raise EOFError("subprocess closed stdout before a full message arrived")
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(f"no message within {timeout}s")
+                self.cond.wait(remaining)
+
+    def read_response(self, expect_id, timeout=READ_TIMEOUT):
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(f"no response for id={expect_id} within {timeout}s")
+            msg = self.read_message(timeout=remaining)
+            if msg.get("id") == expect_id:
+                return msg
+            sys.stderr.write(f"smoke: skipping unsolicited message: {msg}\n")
+
+
+def write_message(stream, obj):
+    body = json.dumps(obj).encode("utf-8")
+    stream.write(f"Content-Length: {len(body)}\r\n\r\n".encode("ascii"))
+    stream.write(body)
+    stream.flush()
+
+
+def drain_stderr(proc):
+    proc.kill()
+    try:
+        proc.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        return proc.stderr.read().decode(errors="replace")
+    except Exception:
+        return ""
+
+
+def fail(proc, msg):
+    err = drain_stderr(proc)
+    sys.stderr.write(f"smoke check FAILED: {msg}\n")
+    if err:
+        sys.stderr.write(f"--- child stderr ---\n{err}\n")
+    sys.exit(1)
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.stderr.write("usage: smoke_check.py <path-to-sextant-binary>\n")
+        sys.exit(2)
+    binary = sys.argv[1]
+
+    try:
+        proc = subprocess.Popen(
+            [binary],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except OSError as e:
+        sys.stderr.write(f"smoke check FAILED to spawn {binary}: {e}\n")
+        sys.exit(2)
+
+    framer = Framer(proc)
+
+    try:
+        write_message(proc.stdin, {
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"processId": None, "rootUri": None, "capabilities": {}},
+        })
+        resp = framer.read_response(1)
+        name = resp.get("result", {}).get("serverInfo", {}).get("name")
+        if name != "Sextant":
+            fail(proc, f"initialize: expected serverInfo.name == 'Sextant', got {name!r}")
+
+        write_message(proc.stdin, {
+            "jsonrpc": "2.0", "method": "initialized", "params": {},
+        })
+
+        uri = "file:///tmp/smoke-check.lisp"
+        write_message(proc.stdin, {
+            "jsonrpc": "2.0", "method": "textDocument/didOpen",
+            "params": {"textDocument": {
+                "uri": uri, "languageId": "lisp", "version": 1,
+                "text": "(mapcar #'identity '(1 2 3))\n",
+            }},
+        })
+
+        write_message(proc.stdin, {
+            "jsonrpc": "2.0", "id": 2, "method": "textDocument/hover",
+            "params": {
+                "textDocument": {"uri": uri},
+                "position": {"line": 0, "character": 4},
+            },
+        })
+        resp = framer.read_response(2)
+        result = resp.get("result")
+        value = (result or {}).get("contents", {}).get("value", "")
+        if not value:
+            fail(proc, f"hover: expected non-empty contents.value, got {result!r}")
+
+        write_message(proc.stdin, {"jsonrpc": "2.0", "id": 3, "method": "shutdown"})
+        framer.read_response(3)
+        write_message(proc.stdin, {"jsonrpc": "2.0", "method": "exit"})
+
+        try:
+            proc.wait(timeout=SHUTDOWN_GRACE)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+
+        print("smoke check passed")
+        sys.exit(0)
+
+    except (TimeoutError, EOFError, ValueError, OSError) as e:
+        err = drain_stderr(proc)
+        sys.stderr.write(f"smoke check FAILED (infra): {e}\n")
+        if err:
+            sys.stderr.write(f"--- child stderr ---\n{err}\n")
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/roswell/sextant.ros
+++ b/roswell/sextant.ros
@@ -1,0 +1,21 @@
+#!/bin/sh
+#|-*- mode:lisp -*-|#
+#|
+exec ros -Q -- $0 "$@"
+|#
+(progn
+  (ros:ensure-asdf)
+  #+quicklisp (ql:quickload :sextant :silent t))
+
+(defpackage :ros.script.sextant
+  (:use :cl))
+(in-package :ros.script.sextant)
+
+(defun main (&rest argv)
+  (declare (ignore argv))
+  ;; quickload :silent t rebinds *standard-output* for the load; transport.lisp's
+  ;; (defvar *lsp-output* *standard-output*) captures that silenced stream at load
+  ;; time, so reset both to the live stdio streams before serving.
+  (setf sextant::*lsp-input* *standard-input*
+        sextant::*lsp-output* *standard-output*)
+  (sextant:main))

--- a/sextant.asd
+++ b/sextant.asd
@@ -31,7 +31,8 @@
   :serial t
   :components ((:module "tests"
                 :components
-                ((:file "diagnostics-test"))))
+                ((:file "diagnostics-test")
+                 (:file "introspection-test"))))
   :perform (test-op (op c)
              (unless (uiop:symbol-call :sextant/tests '#:run-tests)
                (error "sextant/tests: fiveam suite reported failures"))))

--- a/sextant.asd
+++ b/sextant.asd
@@ -23,4 +23,15 @@
                  (:file "dap-handlers")
                  (:file "dap-server")
                  (:file "server")
-                 (:file "main")))))
+                 (:file "main"))))
+  :in-order-to ((test-op (test-op "sextant/tests"))))
+
+(defsystem "sextant/tests"
+  :depends-on ("sextant" "fiveam")
+  :serial t
+  :components ((:module "tests"
+                :components
+                ((:file "diagnostics-test"))))
+  :perform (test-op (op c)
+             (unless (uiop:symbol-call :sextant/tests '#:run-tests)
+               (error "sextant/tests: fiveam suite reported failures"))))

--- a/src/diagnostics.lisp
+++ b/src/diagnostics.lisp
@@ -41,17 +41,26 @@
 ;;; --- Source location extraction from SBCL compiler internals ---
 
 #+sbcl
+(defun context-source-path (ctx)
+  "Return CTX's source-path list, trying both slot names SBCL uses depending
+on whether CTX is an IR1 node (SOURCE-PATH) or a COMPILER-ERROR-CONTEXT
+struct (PATH). Returns a list or NIL."
+  (or (and (ignore-errors (slot-boundp ctx 'sb-c::path))
+           (ignore-errors (slot-value ctx 'sb-c::path)))
+      (and (ignore-errors (slot-boundp ctx 'sb-c::source-path))
+           (ignore-errors (slot-value ctx 'sb-c::source-path)))))
+
+#+sbcl
 (defun extract-source-path-position (text)
   "Extract a precise source position from SBCL's source-path data when available.
 Source-paths are set on IR nodes and encode the exact form path.
 Returns (line . col) or NIL."
   (when (and (boundp 'sb-c::*compiler-error-context*)
              (symbol-value 'sb-c::*compiler-error-context*))
-    (let ((ctx (symbol-value 'sb-c::*compiler-error-context*)))
-      (when (ignore-errors (slot-boundp ctx 'sb-c::source-path))
-        (let ((sp (ignore-errors (slot-value ctx 'sb-c::source-path))))
-          (when (and sp (listp sp))
-            (extract-position-from-source-path sp text)))))))
+    (let* ((ctx (symbol-value 'sb-c::*compiler-error-context*))
+           (sp (context-source-path ctx)))
+      (when (and sp (listp sp))
+        (extract-position-from-source-path sp text)))))
 
 #+sbcl
 (defun extract-compiler-context-position (text)
@@ -63,10 +72,9 @@ Returns (line . col) or NIL."
     (let ((ctx (symbol-value 'sb-c::*compiler-error-context*)))
       (or
        ;; Source-path: precise sub-form position (IR nodes only)
-       (when (ignore-errors (slot-boundp ctx 'sb-c::source-path))
-         (let ((sp (ignore-errors (slot-value ctx 'sb-c::source-path))))
-           (when (and sp (listp sp))
-             (extract-position-from-source-path sp text))))
+       (let ((sp (context-source-path ctx)))
+         (when (and sp (listp sp))
+           (extract-position-from-source-path sp text)))
        ;; File-position: position after reading the enclosing top-level form.
        ;; Rough — points to the form boundary, not the exact error site.
        (when (typep ctx 'sb-c::compiler-error-context)
@@ -255,10 +263,12 @@ Returns (line . col) or NIL."
           "(?i)The (?:variable|function)\\s+([A-Z0-9*+/<>=.!?_-]+)\\s+is" msg)
        (declare (ignore match))
        (when groups (aref groups 0)))
-     ;; 'Constant "..." conflicts' - extract the function containing it
+     ;; 'Constant "..." conflicts' - the offending form is the string literal
+     ;; itself, so keep the quotes: find-symbol-position-in-text must match
+     ;; inside the string, not skip it as it would for a bare symbol name.
      (multiple-value-bind (match groups)
          (cl-ppcre:scan-to-strings
-          "(?i)Constant\\s+\"([^\"]+)\"" msg)
+          "(?i)Constant\\s+(\"[^\"]+\")" msg)
        (declare (ignore match))
        (when groups (aref groups 0))))))
 

--- a/src/lisp-introspection.lisp
+++ b/src/lisp-introspection.lisp
@@ -28,10 +28,11 @@ Returns (values symbol package) or NIL."
           (multiple-value-bind (sym status) (find-symbol uname pkg)
             (when status
               (return-from find-symbol-in-packages (values sym pkg)))))))
-    ;; Search all packages
+    ;; Search all packages. Non-exported (:internal) symbols count too, or
+    ;; project-local package functions never resolve for hover/completion.
     (dolist (pkg (list-all-packages))
       (multiple-value-bind (sym status) (find-symbol uname pkg)
-        (when (eq status :external)
+        (when status
           (return-from find-symbol-in-packages (values sym pkg)))))))
 
 (defvar *hover-max-width* 72

--- a/tests/diagnostics-test.lisp
+++ b/tests/diagnostics-test.lisp
@@ -1,0 +1,34 @@
+(defpackage :sextant/tests
+  (:use :cl :fiveam)
+  (:import-from :sextant
+                #:compile-buffer-for-diagnostics
+                #:captured-condition-position
+                #:captured-condition-source-form
+                #:make-diagnostic-range
+                #:json-get)
+  (:export #:run-tests))
+
+(in-package :sextant/tests)
+
+(def-suite :sextant-tests)
+(in-suite :sextant-tests)
+
+(defparameter *type-mismatch-fixture*
+  (format nil "(defun bad-add (x)~%  (+ x \"not-a-number\"))~%")
+  "Line 1 (0-indexed) has a type mismatch: adding a string to a number.
+Reproduces TODO.md bug #1 on unpatched master: position collapses to NIL,
+make-diagnostic-range then defaults to line 0, col 0.")
+
+(test diagnostics-position-mid-file
+  (let* ((conditions (compile-buffer-for-diagnostics *type-mismatch-fixture* "file:///fixture.lisp"))
+         (cc (first conditions))
+         (pos (and cc (captured-condition-position cc))))
+    (is (not (null cc)))
+    (is (not (null pos)))
+    (is (eql 1 (car pos)))
+    (let ((range (make-diagnostic-range pos *type-mismatch-fixture*
+                                         (captured-condition-source-form cc))))
+      (is (eql 1 (json-get (json-get range "start") "line"))))))
+
+(defun run-tests ()
+  (run! :sextant-tests))

--- a/tests/diagnostics-test.lisp
+++ b/tests/diagnostics-test.lisp
@@ -5,7 +5,8 @@
                 #:captured-condition-position
                 #:captured-condition-source-form
                 #:make-diagnostic-range
-                #:json-get)
+                #:json-get
+                #:find-symbol-in-packages)
   (:export #:run-tests))
 
 (in-package :sextant/tests)

--- a/tests/introspection-test.lisp
+++ b/tests/introspection-test.lisp
@@ -1,0 +1,22 @@
+(in-package :sextant/tests)
+
+(in-suite :sextant-tests)
+
+(test find-symbol-resolves-internal-subpackage-symbol
+  "Reproduces TODO.md bug #4 on unpatched master: find-symbol-in-packages only
+matched :external symbols once it fell through to the all-packages search, so
+a function defined in a project-local package without being exported (the
+common case for subpackage code) was invisible to hover/completion, unlike
+the same function defined in COMMON-LISP-USER."
+  (let* ((pkg (or (find-package "SEXTANT-TESTS-FIXTURE-PKG")
+                   (make-package "SEXTANT-TESTS-FIXTURE-PKG" :use nil)))
+         (sym (intern "SEXTANT-TESTS-FIXTURE-FN" pkg)))
+    (unwind-protect
+         (progn
+           (setf (symbol-function sym) (lambda () 42))
+           (is (eq :internal (nth-value 1 (find-symbol "SEXTANT-TESTS-FIXTURE-FN" pkg))))
+           (multiple-value-bind (found-sym found-pkg)
+               (find-symbol-in-packages "sextant-tests-fixture-fn")
+             (is (eq sym found-sym))
+             (is (eq pkg found-pkg))))
+      (delete-package pkg))))


### PR DESCRIPTION
Bundle of five related changes:

1. feat(roswell): add Roswell install script (65eef7f)
  - Adds roswell/sextant.ros so users can install sextant from source with ros install.
  - Resets the captured LSP output stream before server startup, avoiding a silent-quickload stream-capture issue.
2. fix(diagnostics): report real source positions instead of 0:0 (888d262)
  - Fixes diagnostics collapsing to 0:0 for quoted constants (e.g. type-mismatch string literals) by keeping the quotes during position search.
  - Fixes slot-name lookup (SOURCE-PATH -> PATH) when SBCL’s *compiler-error-context* is a struct instead of an IR1 node.
  - Adds the first ASDF/fiveam test system (sextant/tests) with a regression test.
3. feat(ci): add release workflow with stdio smoke check (d2e35da)
  - Adds .github/workflows/release.yml to build sextant for linux-x64, linux-arm64, and macos-arm64 and publish GitHub releases on v* tags.
  - Adds ci/smoke_check.py for a JSON-RPC stdio smoke check before artifact upload.
4. ci: run tests on master pushes and PRs (e79b7c5)
  - Adds a `make test` target that runs the fiveam suite via asdf:test-system.
  - Wires it into the release workflow as a step before the binary build, so tests run on every matrix platform.
  - Retargets the workflow trigger from the unused `packaging` branch to `master` plus pull requests; tag pushes still gate the publish job.
5. fix(introspection): resolve non-exported package symbols (0c18039)
  - find-symbol-in-packages accepted only :external symbols in its all-packages fallback, so a non-exported project-package function never resolved for hover/completion while the same symbol in COMMON-LISP-USER did; now accepts :internal too.
  - Adds a fiveam regression test (tests/introspection-test.lisp) that fails on the old behavior.
  - Drops the two now-fixed entries from TODO.md (this bug and the earlier diagnostics line/col fix).